### PR TITLE
chore: adjust simulate trace filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ Where:
 
 - `timestamp`: The time when the trace file was created, in ISO 8601 format, with colons and periods removed.
 - `lastRound`: The last round when the simulation was performed.
-- `transactionTypes`: A string representing the types and counts of transactions in the atomic group. Each transaction type is represented as `${count}#${type}`, and different transaction types are separated by underscores.
+- `transactionTypes`: A string representing the types and counts of transactions in the atomic group. Each transaction type is represented as `${count}${type}`, and different transaction types are separated by underscores.
 
-For example, a trace file might be named `20220301T123456Z_lr1000_2#pay_1#axfer.trace.avm.json`, indicating that the trace file was created at `2022-03-01T12:34:56Z`, the last round was `1000`, and the atomic group contained 2 payment transactions and 1 asset transfer transaction.
+For example, a trace file might be named `20220301T123456Z_lr1000_2pay_1axfer.trace.avm.json`, indicating that the trace file was created at `2022-03-01T12:34:56Z`, the last round was `1000`, and the atomic group contained 2 payment transactions and 1 asset transfer transaction.
 
 ## Guiding principles
 

--- a/src/debugging/writeAVMDebugTrace.ts
+++ b/src/debugging/writeAVMDebugTrace.ts
@@ -30,7 +30,7 @@ export async function writeAVMDebugTrace(input: AVMTracesEventData): Promise<voi
     }, {})
 
     const txnTypesStr = Object.entries(txnTypesCount)
-      .map(([type, count]) => `${count}#${type}`)
+      .map(([type, count]) => `${count}${type}`)
       .join('_')
 
     const timestamp = new Date().toISOString().replace(/[:.]/g, '')


### PR DESCRIPTION
Remove the `#` character from the simulate trace filename, as it's probably best to use "POSIX Fully portable filenames".