### PR TITLE
chore: align debug traces dir name with algokit-utils-py behaviour

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
         pipx install algokit
         algokit localnet start
         npx --yes wait-on tcp:4001 -t 30000
-        npm install --no-package-lock
+        npm ci --ignore-scripts
       audit-script: |
         npm run audit
   check_docs:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Then to import it and activate `utils-ts` debugging:
 
 ```typescript
 import { Config } from '@algorandfoundation/algokit-utils'
-import { registerDebugEventHandlers() } from '@algorandfoundation/algokit-utils-debug'
+import { registerDebugEventHandlers } from '@algorandfoundation/algokit-utils-debug'
 
 Config.configure({
   debug: true,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 const ALGOKIT_DIR = '.algokit'
 const SOURCES_DIR = 'sources'
-const DEBUG_TRACES_DIR = 'debug-traces'
+const DEBUG_TRACES_DIR = 'debug_traces'
 const TEAL_FILE_EXT = '.teal'
 const TEAL_SOURCEMAP_EXT = '.teal.map'
 const DEFAULT_MAX_SEARCH_DEPTH = 10


### PR DESCRIPTION
## Proposed changes

- Minor typo rename to align with the folder name generated in algokit-utils-py