### PR TITLE
ci: use bot token for release workflow

### DIFF
--- a/.github/workflows/prod_release.yml
+++ b/.github/workflows/prod_release.yml
@@ -10,17 +10,24 @@ jobs:
   prod_release:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate bot token
+        uses: actions/create-github-app-token@v1
+        id: app_token
+        with:
+          app-id: ${{ secrets.BOT_ID }}
+          private-key: ${{ secrets.BOT_SK }}
       - name: Clone repository
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{ steps.app_token.outputs.token }}
       - name: Merge main -> release
         uses: devmasx/merge-branch@854d3ac71ed1e9deb668e0074781b81fdd6e771f
         with:
           type: now
           from_branch: main
           target_branch: release
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.app_token.outputs.token }}
       - name: Merge release -> main
         uses: devmasx/merge-branch@854d3ac71ed1e9deb668e0074781b81fdd6e771f
         with:
@@ -28,4 +35,4 @@ jobs:
           from_branch: release
           target_branch: main
           message: Merge release back to main to get version increment [no ci]
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.app_token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,10 +60,18 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - name: Generate bot token
+        uses: actions/create-github-app-token@v1
+        id: app_token
+        with:
+          app-id: ${{ secrets.BOT_ID }}
+          private-key: ${{ secrets.BOT_SK }}
+
       - name: Clone repository
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{ steps.app_token.outputs.token }}
 
       # semantic-release needs node 20
       - name: Use Node.js 20.x
@@ -89,5 +97,5 @@ jobs:
       - name: 'Semantic release'
         run: npx semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Utilizes a bot token instead of the default GITHUB_TOKEN for the release workflow.

